### PR TITLE
New feature: follow-mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,5 +48,7 @@ Specify timeout of ping in seconds, simply passed to wrapped ping command
 Specify interval of backgroung-pings. **Not** depending on wrapped ping command. Default 1 second.
 #### fuzzy-logic (-f \<# of pings\>)
 Number of pings that may fail, but still keep target status "up". Target will go "down" after #+1 failed pings. Useful to set >0 on unrealiable networks like cellular, where packetloss is expected. Default 0, so target goes "down" after the 0+1 = first failed ping.
+#### static legacy mode (-s)
+Version 6.0 introduced a dynamic "follow-mode" as default, which allows to see rtt of every single ping command. Before 6.0 you could only see the rtt when state changes occured. Those working with tping sice the beginning might got used to the fact, that the tping-output-line is always completely frozen and if you see something change, it means that your ping-host got lost and your adrenalin-level will rise immediately. For preventing network-admin heart-attacks because of the new dynamic output - use this parameter.
 #### AAAA DNS Support
 Since v3.1 tping defaults to IPv6 (AAAA) records when resolving DNS. When AAAA-record is unavailable, tping falls back to IPv4 A-record. If you want to disable this (i.e. IPv6 is not running, script should not waste time with it), you can temporarily use "-4" switch with each command or permanently set "ipv=4" instead of "ipv=6" in preamble of the script.

--- a/tping.sh
+++ b/tping.sh
@@ -34,7 +34,6 @@ debug=0
 # some other default values, mostly controlled by parameters
 #health stores tristate value meaning 0=dead, 1=alive, 2=ontime-startup-only-state (dead or alive)
 health=2
-mytime=$(date +%s)
 #parameter for ping binary
 deadtime=1
 #time between pings. as we doing only single pings this is use as internal delay parameter 
@@ -54,11 +53,13 @@ YELLOW="\033[0;33m"
 RESET="\033[0m"
 
 # some statistical values
+lastuptime=0
+lastdowntime=0
 transmitted=0
 received=0
-down=0
+downtotal=0
 downsec=0
-up=0
+uptotal=0
 upsec=0
 flap=0
 rtt=()
@@ -69,13 +70,13 @@ function print_statistics() {
 	echo -e "\n--- $host ($hostdig) tping statistics ---"
 
 	if [[ $health -eq 1 ]]; then
-		upsec=$(date +%s)-$mytime
-		up=$((up + upsec))
+		upsec=$(date +%s)-$lastuptime
+		uptotal=$((uptotal + upsec))
 	elif [[ $health -eq 0 ]] ;then
-		downsec=$(date +%s)-$mytime
-		down=$((down + downsec))
+		downsec=$(date +%s)-$lastdowntime
+		downtotal=$((downtotal + downsec))
 	fi
-	echo "flapped $flap times, was up for $(displaytime $up) and down for $(displaytime $down)"
+	echo "flapped $flap times, was up for $(displaytime $uptotal) and down for $(displaytime $downtotal)"
 
 	# check if 'bc' is installed on system, if yes print detailed (floating point) statistics
 	if [[ -n $(which bc) ]]; then
@@ -226,6 +227,7 @@ if [[ $debug -eq 1 ]]; then
 	echo -e "\tdeadtime  = [ $deadtime ]"
 	echo -e "\tinterval = [ $interval ]"
 	echo -e "\tfuzzy = [ $fuzzy ]"
+	echo -e "\tfollow = [ $follow ]"
 	echo -e "\thost = [ $host ]"
 	echo -e "\tip = [ $ip ]"
 	echo -e "\tping command = [ $ping ]"
@@ -238,10 +240,11 @@ if [[ -z "$host" ]]; then
 fi
 
 if [[ "$fuzzy" -gt 0 ]]; then
-	echo -e "\nNote: fuzzy dead-detection in effect, will ignore up to $fuzzy failed pings. Use for unreliable connections only.\n"
+	echo -e "\nNote: fuzzy dead-detection in effect, will ignore up to $fuzzy failed pings (you will see a --FUZZY-- indicator if in action). Use for unreliable connections only.\n"
 fi
 
 ## 3 - do the ping in loop
+tput sc
 while :; do
 	transmitted=$((transmitted + 1))
 	result=$($ping | grep 'icmp_seq=.*time=')
@@ -250,30 +253,69 @@ while :; do
 		myfuzzy=$((myfuzzy + 1))
 		if [[ $myfuzzy -gt "$fuzzy" ]]; then
 			if [[ $health -eq 2 ]]; then #start to down
+				lastdowntime=$(date +%s)
+				if [ $debug -eq 1 ]; then
+					echo -en "debug:STD;result=$result;rv=$rv;health=$health "
+				fi
 				echo -e "$(date +'%Y-%m-%d %H:%M:%S') | host $host ($hostdig) is ${RED}down${RESET}"
-			elif [[ $health -eq 1 ]]; then
-				upsec=$(date +%s)-$mytime
-				up=$((up + upsec))
+				health=0
+			elif [[ $health -eq 1 ]]; then #up to down
+				lastdowntime=$(date +%s)
+				upsec=$(date +%s)-$lastuptime
+				uptotal=$((uptotal + upsec))
 				flap=$((flap + 1))
+				tput rc; tput el
+				if [ $debug -eq 1 ]; then
+					echo -en "debug:UTD;result=$result;rv=$rv;health=$health "
+				fi
 				echo -e "$(date +'%Y-%m-%d %H:%M:%S') | host $host ($hostdig) is ${RED}down${RESET} [ok for $(displaytime "$upsec")]"
-				mytime=$(date +%s)
+				tput sc
+				health=0
+			elif [ $health -eq 0 ] && [ $follow -eq 1 ]; then #down to down
+				downsec=$(date +%s)-$lastdowntime
+				tput rc; tput el
+				if [ $debug -eq 1 ]; then
+					echo -en "debug:DTU;result=$result;rv=$rv;health=$health "
+				fi
+				echo -en "$(date +'%Y-%m-%d %H:%M:%S') | host $host ($hostdig) is ${RED}down${RESET} for $(displaytime "$downsec")"
 			fi
-			health=0
+		else #we're in fuzzy-detection now. pings fail, but will not consider down
+			if [ $myfuzzy -eq 1 ]; then #only on 1st fuzzy-ping, show hint, next successful ping will clear whole line
+				echo -n " --FUZZY--"
+			fi
+			#NOP - for the user it's like pausing output what we tried to eliminate. this is the only point where tping behaves like that, but may be ok in this cornercase.
 		fi
 	else #ping successful
 		received=$((received + 1))
 		rtt[$transmitted]=$(echo "$result" | cut -d "=" -f 4  | cut -d ' ' -f 1)
 		myfuzzy=0
 		if [[ $health -eq 2 ]]; then #start to up
+			lastuptime=$(date +%s)
+			if [ $debug -eq 1 ]; then
+				echo -en "debug:STU;result=$result;rv=$rv;health=$health "
+			fi
 			echo -e "$(date +'%Y-%m-%d %H:%M:%S') | host $host ($hostdig) is ${GREEN}ok${RESET} | RTT ${rtt[$transmitted]}ms"
-		elif [[ $health -eq 0 ]] ;then
-			downsec=$(date +%s)-$mytime
-			down=$((down + downsec))
+			health=1
+		elif [[ $health -eq 0 ]]; then #down to up
+			tput rc; tput el
+			downsec=$(date +%s)-$lastdowntime
+			downtotal=$((downtotal + downsec))
 			flap=$((flap + 1))
+			if [ $debug -eq 1 ]; then
+				echo -en "debug:DTU;result=$result;rv=$rv;health=$health "
+			fi
 			echo -e "$(date +'%Y-%m-%d %H:%M:%S') | host $host ($hostdig) is ${GREEN}ok${RESET} [down for $(displaytime "$downsec")] | RTT ${rtt[$transmitted]}ms"
-			mytime=$(date +%s)
+			tput sc
+			lastuptime=$(date +%s)
+			health=1
+		elif [ $health -eq 1 ] && [ $follow -eq 1 ]; then #up to up
+			upsec=$(date +%s)-$lastuptime
+			tput rc; tput el
+			if [ $debug -eq 1 ]; then
+				echo -en "debug:UTU;result=$result;rv=$rv;health=$health "
+			fi
+			echo -en "$(date +'%Y-%m-%d %H:%M:%S') | host $host ($hostdig) is ${GREEN}ok${RESET} for $(displaytime "$upsec") | RTT ${rtt[$transmitted]}ms"
 		fi
-		health=1
 		# delay between pings
 		sleep "$interval"
 	fi

--- a/tping.sh
+++ b/tping.sh
@@ -129,16 +129,18 @@ usage () {
 	echo -e "usage: $(basename "$0") [-vhd4] [-W deadtime] [-i interval]
 		\t[-f fuzzy-pings (# failed pings before marking down)]
 		\t[-4 (use IPv4-only for DNS-lookup)]
+		\t[-s (use legacy static mode without rtt live-updates)]
 		\t<Traget IP or DNS-Name>"
 }
 
 _options () {
-	while getopts ":vhdW:i:f:4" opt; do :
+	while getopts ":vhdW:i:f:s4" opt; do :
 		case $opt in
 			4 ) ipv=4 ;;
 			W ) deadtime=$OPTARG ;;
 			i ) interval=$OPTARG ;;
 			f ) fuzzy=$OPTARG ;;
+			s ) follow=0 ;;
 			d ) debug=1 ;;
 			h ) usage
 				exit 0;;

--- a/tping.sh
+++ b/tping.sh
@@ -32,13 +32,20 @@ ipv=6
 debug=0
 
 # some other default values, mostly controlled by parameters
+#health stores tristate value meaning 0=dead, 1=alive, 2=ontime-startup-only-state (dead or alive)
 health=2
 mytime=$(date +%s)
+#parameter for ping binary
 deadtime=1
+#time between pings. as we doing only single pings this is use as internal delay parameter 
 interval=1
+#paramter for fuzzy-dead detection
 fuzzy=0
 myfuzzy=0
+#version of ip-protocol to be used (4/6)
 ip=0
+#follow-function (on/off)
+follow=1
 
 # some constants for bash-coloring
 RED="\033[0;31m"
@@ -56,6 +63,7 @@ upsec=0
 flap=0
 rtt=()
 
+# Functions
 # print final statistics on exit
 function print_statistics() {
 	echo -e "\n--- $host ($hostdig) tping statistics ---"
@@ -241,7 +249,7 @@ while :; do
 	if [[ $rv -gt 0 ]]; then
 		myfuzzy=$((myfuzzy + 1))
 		if [[ $myfuzzy -gt "$fuzzy" ]]; then
-			if [[ $health -eq 2 ]]; then
+			if [[ $health -eq 2 ]]; then #start to down
 				echo -e "$(date +'%Y-%m-%d %H:%M:%S') | host $host ($hostdig) is ${RED}down${RESET}"
 			elif [[ $health -eq 1 ]]; then
 				upsec=$(date +%s)-$mytime
@@ -252,11 +260,11 @@ while :; do
 			fi
 			health=0
 		fi
-	else
+	else #ping successful
 		received=$((received + 1))
 		rtt[$transmitted]=$(echo "$result" | cut -d "=" -f 4  | cut -d ' ' -f 1)
 		myfuzzy=0
-		if [[ $health -eq 2 ]] ;then
+		if [[ $health -eq 2 ]]; then #start to up
 			echo -e "$(date +'%Y-%m-%d %H:%M:%S') | host $host ($hostdig) is ${GREEN}ok${RESET} | RTT ${rtt[$transmitted]}ms"
 		elif [[ $health -eq 0 ]] ;then
 			downsec=$(date +%s)-$mytime

--- a/tping.sh
+++ b/tping.sh
@@ -20,7 +20,7 @@
 
 ## 0 - constants, variables, settings
 # actual Version
-VER="5.1"
+VER="5.1_feat-followmode"
 
 # user-controlled variables
 # default for DNS-lookup when using a hostname instead of IP-address


### PR DESCRIPTION
At first there is the fundamental reason for tping: To only monitor the change of up/down status - at lowest cost of toolsets. Or spoken differently as copied from description:
```
What you lose, is the continous reading of the RTT (you only get the first one)
What you win is a clear, timestamped view when and how long a target host went off or online
```
I thought about combining both. Dominating user experience must be the clear view of up/down events, but maybe we can put some cream on top of it.

My idea was to create an extra "status"-line at bottom, clearing it every time tping pings. Here are some questions about my first implementation:

1. only way i found so far was using 'tput' with string output paramerers (list [here](https://programmer.group/detailed-explanation-of-linux-tput-command.html)). the perfect match parameter 'ell' did somehow not work, so i workarounded with 'sc', 'rc' and 'el'. 
2. working with tput 'el' (or possibly also 'ell') has issues, when console windows forces a line break, then my code does not work. i added some more debug, so try with -d to get a longer line.
3. i think it's a big plus to see actual values of rtt, but does it distort too much to enable it per default? if we use a new switch, i would expect -f for follow, as this is pretty common elsewhere. But then we have to rename the fuzzy-feature (i'm not too proud of this name...) or we activate per default and create a new switch (i.e. -s for wellknown "static"-mode)
4. Try follow mode with fuzzy mode, i think the combination of both in action looks quite nice, you can see if fuzzy is in action now.

Biggest changes in code are:

- adding a third clause in each host-up and host-down main-loop. this also made some statistic things easier and looks better in general i think
- adding some 'tput' lines in each clause and before the main loop