### PR TITLE
 fix: match only successful pings on linux & macOS (after force push)

### DIFF
--- a/tping.sh
+++ b/tping.sh
@@ -235,8 +235,9 @@ fi
 ## 3 - do the ping in loop
 while :; do
 	transmitted=$((transmitted + 1))
-	result=$($ping | grep 'icmp_seq=')
-	if [[ $? -gt 0 ]]; then
+	result=$($ping | grep 'icmp_seq=.*time=')
+	rv=$?
+	if [[ $rv -gt 0 ]]; then
 		myfuzzy=$((myfuzzy + 1))
 		if [[ $myfuzzy -gt "$fuzzy" ]]; then
 			if [[ $health -eq 2 ]]; then

--- a/tping.sh
+++ b/tping.sh
@@ -14,12 +14,13 @@
 # git version control
 # v3.1 2021-08-18 /schwupp - added fallback to IPv4 if no IPv6 found in DNS
 # v4.0 2022-03-27 /lippl - added support for macos, PR #1
-# v5.0 2024-02-04 /lippl - stats-on-exit, PR #4
+# v5.0 2023-02-04 /lippl - stats-on-exit, PR #4
+# v5.1 2023-05-26 /schwupp - fix match/grep of ping-cmd in linux/macos
 ####
 
 ## 0 - constants, variables, settings
 # actual Version
-VER="5.0"
+VER="5.1"
 
 # user-controlled variables
 # default for DNS-lookup when using a hostname instead of IP-address


### PR DESCRIPTION
had to open new (duplicate) PR, as old one was already merged and merged PRs cannot be re-opened. as merged commit had to be reverted by force push, we need this PR to document the change

for history see #8 

fixes #5 