### PR TITLE
fix: tping crashes when dig returns multiple ips

### DIFF
--- a/tping.sh
+++ b/tping.sh
@@ -229,24 +229,27 @@ elif [[ $host =~ (([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1
 # it's a name-parameter
 else
         if [[ $ipv -eq 6 ]]; then
-                declare -a hostdig2=($(dig AAAA +search +short +nocookie "$host"  | grep -v '\.$'))
-                if [[ ${#hostdig2[@]} -gt 1 ]]; then
-                        echo -e "${YELLOW}Warning:${RESET} $host has multiple IPv6 addresses (${hostdig2[@]})- using first one."
-                        hostdig=${hostdig2[0]}
-                elif [[ ${#hostdig2[@]} -eq 0 ]]; then
+                declare -a hostdigs=($(dig AAAA +search +short +nocookie "$host"  | grep -v '\.$'))
+                if [[ ${#hostdigs[@]} -gt 1 ]]; then
+                        echo -e "${YELLOW}Warning: $host has multiple IPv6 addresses (${hostdigs[@]}) - using first one."${RESET}
+                        hostdig=${hostdigs[0]}
+                elif [[ ${#hostdigs[@]} -eq 0 ]]; then
                         echo -e "${YELLOW}Warning: No v6 DNS for $host - trying v4 DNS...${RESET}"
                         ipv=4
                 fi
-		hostdig=${hostdig2[0]}
         fi
         if [[ $ipv -eq 4 ]]; then
-                hostdig=$(dig A +search +short "$host" | grep -v '\.$')
-                if [[ -z "$hostdig" ]]; then
+		declare -a hostdigs=($(dig A +search +short "$host" | grep -v '\.$'))
+                if [[ ${#hostdigs[@]} -gt 1 ]]; then
+                        echo -e "${YELLOW}Warning: $host has multiple IPv4 addresses (${hostdigs[@]}) - using first one."${RESET}
+                        hostdig=${hostdigs[0]}
+                elif [[ ${#hostdigs[@]} -eq 0 ]]; then
                         echo -e "${RED}Error: No v4 DNS for $host - exiting now.${RESET}"
                         exit 1
                 fi
         fi
-        ip=$hostdig
+        hostdig=${hostdigs[0]}
+        ip=${hostdigs[0]}
 fi
 
 ## 2 - build ping-cmd


### PR DESCRIPTION
fixes #10 
changed hostdig-function to use arrays as return value, so that multiple answers can be identified. before tping crashed, new default is to use first DNS answer.